### PR TITLE
few small changes in docstrings

### DIFF
--- a/homeassistant/components/watergate/entity.py
+++ b/homeassistant/components/watergate/entity.py
@@ -43,7 +43,7 @@ class WatergateEntity(CoordinatorEntity[WatergateDataCoordinator]):
 
 @dataclass
 class WatergateData:
-    """Data for the A. O. Smith integration."""
+    """Data for the Watergate integration."""
 
     client: WatergateLocalApiClient
     coordinator: WatergateDataCoordinator

--- a/homeassistant/components/watergate/valve.py
+++ b/homeassistant/components/watergate/valve.py
@@ -21,7 +21,7 @@ async def async_setup_entry(
     config_entry: WatergateConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up all entries for Wolf Platform."""
+    """Set up all entries for Watergate Platform."""
 
     async_add_entities(
         [SonicValve(config_entry.runtime_data.coordinator, config_entry)]
@@ -81,7 +81,7 @@ class SonicValve(WatergateEntity, ValveEntity):
         self.async_write_ha_state()
 
     async def async_close_valve(self, **kwargs: Any) -> None:
-        """Open the valve."""
+        """Close the valve."""
         await self._api_client.async_set_valve_state("close")
         self._valve_state = ValveState.CLOSING
         self.async_write_ha_state()


### PR DESCRIPTION
Hi Adam, well done on the integration, this PR is just a couple of small changes to docstrings.

* [`homeassistant/components/watergate/entity.py`](diffhunk://#diff-1f335d25664dc2b7111d682f69884ef952647754aec4289d00d87cfb28f5be04L46-R46): Updated the class docstring to refer to the Watergate integration instead of the A. O. Smith integration.
* [`homeassistant/components/watergate/valve.py`](diffhunk://#diff-ed9171ddd137b6ed5a76e155a0e086b62dceb918eb3d870bf9dc79827386ae34L24-R24): Updated the function docstring to refer to the Watergate Platform instead of the Wolf Platform.
* [`homeassistant/components/watergate/valve.py`](diffhunk://#diff-ed9171ddd137b6ed5a76e155a0e086b62dceb918eb3d870bf9dc79827386ae34L84-R84): Updated the docstring for `async_close_valve` to indicate that it closes the valve.